### PR TITLE
Multiple changes

### DIFF
--- a/android9-generic.yaml
+++ b/android9-generic.yaml
@@ -28,7 +28,7 @@ actions:
   - action: run
     chroot: true
     description: Create directories for Android mounts
-    command: mkdir -p /android /mnt/vendor/persist /userdata && ln -s /android/data /data && ln -s /android/system /system && ln -s /android/vendor /vendor && ln -s /android/cache /cache && ln -s /android/persist /persist && ln -s /android/product /product && ln -s /android/metadata /metadata
+    command: mkdir -p /android /mnt/vendor/persist /userdata
 
   - action: run
     chroot: true

--- a/android9-generic.yaml
+++ b/android9-generic.yaml
@@ -28,7 +28,7 @@ actions:
   - action: run
     chroot: true
     description: Create directories for Android mounts
-    command: mkdir -p /android /data /system /system_root /vendor /cache /mnt/vendor/persist /userdata
+    command: mkdir -p /android /mnt/vendor/persist /userdata && ln -s /android/data /data && ln -s /android/system /system && ln -s /android/vendor /vendor && ln -s /android/cache /cache && ln -s /android/persist /persist && ln -s /android/product /product && ln -s /android/metadata /metadata
 
   - action: run
     chroot: true

--- a/android9/overlay/etc/init/mount-android.conf
+++ b/android9/overlay/etc/init/mount-android.conf
@@ -14,5 +14,7 @@ script
     /var/lib/lxc/android/mount-android.sh
 
     mount -o bind /mnt /var/lib/lxc/android/rootfs/mnt
-    mount -o bind /metadata /var/lib/lxc/android/rootfs/metadata
+    if [ -d /android/metadata ]; then
+        mount -o bind /android/metadata /var/lib/lxc/android/rootfs/metadata
+    fi
 end script

--- a/android9/overlay/etc/init/mount-android.conf
+++ b/android9/overlay/etc/init/mount-android.conf
@@ -11,10 +11,8 @@ script
     mkdir -p /dev/cpuset
     mount none /dev/cpuset -t cpuset -o nodev,noexec,nosuid
 
-    mount -o bind /android/system/system /system
-
     /var/lib/lxc/android/mount-android.sh
 
-    mount -o bind /android/data /data
-    mount -o bind /android/system /var/lib/lxc/android/rootfs
+    mount -o bind /mnt /var/lib/lxc/android/rootfs/mnt
+    mount -o bind /metadata /var/lib/lxc/android/rootfs/metadata
 end script

--- a/android9/overlay/etc/init/sensorfw.override
+++ b/android9/overlay/etc/init/sensorfw.override
@@ -1,4 +1,7 @@
+
 description "sensorfw service"
 
 start on started dbus and android
 stop on stopping dbus
+
+exec /usr/sbin/sensorfwd --config-file=/etc/device-info/sensorfw/hybris.conf --log-level=warning --no-magnetometer-bg-calibration

--- a/android9/overlay/etc/sensorfw/sensord.conf.d/sensord.conf
+++ b/android9/overlay/etc/sensorfw/sensord.conf.d/sensord.conf
@@ -1,0 +1,1 @@
+# To be overridden by Halium overrides

--- a/android9/overlay/etc/sensorfw/sensord.conf.d/sensord.conf
+++ b/android9/overlay/etc/sensorfw/sensord.conf.d/sensord.conf
@@ -1,1 +1,0 @@
-# To be overridden by Halium overrides

--- a/android9/overlay/var/lib/lxc/android/mount-android.sh
+++ b/android9/overlay/var/lib/lxc/android/mount-android.sh
@@ -45,6 +45,17 @@ if [ -e $sys_vendor ]; then
     mount $path /vendor -t $type -o $options
 fi
 
+sys_persist="/sys/firmware/devicetree/base/firmware/android/fstab/persist"
+if [ -e $sys_persist ]; then
+    label=$(cat $sys_persist/dev | awk -F/ '{print $NF}')
+    path=$(find_partition_path $label)
+    # [ ! -e "$path" ] && exit "Error persist not found"
+    type=$(cat $sys_persist/type)
+    options=$(parse_mount_flags $(cat $sys_persist/mnt_flags))
+    echo "mounting $path as /mnt/vendor/persist"
+    mount $path /mnt/vendor/persist -t $type -o $options
+fi
+
 # Assume there's only one fstab in vendor
 fstab=$(ls /vendor/etc/fstab*)
 [ ! -e "$fstab" ] && echo "fstab not found" && exit

--- a/scripts/add-android8-repos.sh
+++ b/scripts/add-android8-repos.sh
@@ -22,6 +22,8 @@ apt install -y bluebinder ofono-ril-binder-plugin pulseaudio-modules-droid-28
 # sensorfw
 apt remove -y qtubuntu-sensors
 apt install -y libsensorfw-qt5-hybris libsensorfw-qt5-configs libsensorfw-qt5-plugins libqt5sensors5-sensorfw
+# hfd-service
+apt install -y hfd-service libqt5feedback5-hfd hfd-service-tools
 
 # Restore symlink
 rm /etc/resolv.conf


### PR DESCRIPTION
With halium-install changes merged (https://gitlab.com/JBBgameich/halium-install/-/merge_requests/32) it is now possible to install the systemimage as system-as-root compatible for halium-initramfs to properly setup the Android environment.

This enables mounting the /mnt/vendor/persist partition via the device tree's fstab configuration.